### PR TITLE
Delete links that leads to submit a proposal. Ticket #155.

### DIFF
--- a/config/sync/user.role.admin.yml
+++ b/config/sync/user.role.admin.yml
@@ -63,3 +63,4 @@ permissions:
   - 'access user profiles'
   - 'administer views'
   - 'use text format full_html_ckeditor'
+  - 'create sessions content'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -7,9 +7,8 @@ label: 'Authenticated user'
 weight: 1
 is_admin: false
 permissions:
-  - 'access content'
-  - 'use text format full_html'
-  - 'create sessions content'
-  - 'delete own sessions content'
-  - 'edit own sessions content'
-  - 'access user profiles'
+  0: 'access content'
+  1: 'use text format full_html'
+  3: 'delete own sessions content'
+  4: 'edit own sessions content'
+  5: 'access user profiles'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -9,6 +9,5 @@ is_admin: false
 permissions:
   0: 'access content'
   1: 'use text format full_html'
-  3: 'delete own sessions content'
   4: 'edit own sessions content'
   5: 'access user profiles'

--- a/config/sync/views.view.carousel_proposal.yml
+++ b/config/sync/views.view.carousel_proposal.yml
@@ -375,20 +375,9 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: '<h2>Session Proposals are Open</h2>'
+          content: '<h2>Submitted Proposals</h2>'
           plugin_id: text_custom
-      footer:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content: "<div class=\"camp-button-wrapper\">\n     <a href=\"/node/add/sessions\">\n          <div class=\"camp-button\">Propose a Session</div>\n     </a>\n </div>"
-          plugin_id: text_custom
+      footer: {  }
       empty: {  }
       relationships:
         uid:

--- a/config/sync/views.view.proposals.yml
+++ b/config/sync/views.view.proposals.yml
@@ -844,7 +844,7 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: "<p class=\"speaker-description\">Here are some proposed sessions submitted for the event.</p>\n<p class=\"speaker-announcement\">If you already have an account, <a href=\"/node/add/sessions\">submit a proposal</a>.<br>\nNo account yet? <a href=\"/user/register\"> Click here</a>.</p>"
+          content: "<p class=\"speaker-description\">Here are some proposed sessions submitted for the event.</p>\n<p class=\"speaker-announcement\">No account yet? <a href=\"/user/register\"> Click here</a>.</p>"
           plugin_id: text_custom
       footer: {  }
       empty:

--- a/config/sync/views.view.your_proposals.yml
+++ b/config/sync/views.view.your_proposals.yml
@@ -190,7 +190,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<p>You have not submitted a proposal yet.</p>\n<a href=\"/node/add/sessions\">Submit a proposal now.</a>"
+          content: "<p>You have not submitted a proposal.</p>\n"
           plugin_id: text_custom
       relationships: {  }
       arguments:


### PR DESCRIPTION
Delete the 'submit session' button in the carousel view.
Delete the 'submit a proposal' link in the your proposal view.
Delete the 'submit a proposal link in the page and changed the title 'SESSION PROPOSAL - UNTIL OCT. 27' into 'Come Join Us!'.
Unchecked authenticated users permission of 'create session' option.
@Luukyb 