### PR TITLE
Features 162 new fields user profile

### DIFF
--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.user.user.field_beginner_workshop
+    - field.field.user.user.field_biography
     - field.field.user.user.field_company
     - field.field.user.user.field_drupal_contribute
     - field.field.user.user.field_first_name
@@ -22,20 +24,32 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
+  field_beginner_workshop:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+  field_biography:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
   field_company:
     type: string_textfield
-    weight: 6
+    weight: 4
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   field_drupal_contribute:
     type: options_select
-    weight: 9
+    weight: 8
     settings: {  }
     third_party_settings: {  }
   field_first_name:
-    weight: 3
+    weight: 1
     settings:
       size: 60
       placeholder: ''
@@ -43,18 +57,18 @@ content:
     type: string_textfield
   field_join_code_sprint:
     type: options_select
-    weight: 8
+    weight: 7
     settings: {  }
     third_party_settings: {  }
   field_last_name:
-    weight: 4
+    weight: 2
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
   field_profile_image:
-    weight: 5
+    weight: 3
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -62,17 +76,17 @@ content:
     type: image_image
   field_role:
     type: string_textfield
-    weight: 7
+    weight: 5
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   language:
-    weight: 1
+    weight: 11
     settings: {  }
     third_party_settings: {  }
   timezone:
-    weight: 2
+    weight: 10
     settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/sync/core.entity_view_display.user.user.default.yml
+++ b/config/sync/core.entity_view_display.user.user.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.user.user.field_beginner_workshop
+    - field.field.user.user.field_biography
     - field.field.user.user.field_company
     - field.field.user.user.field_drupal_contribute
     - field.field.user.user.field_first_name
@@ -12,25 +14,25 @@ dependencies:
     - field.field.user.user.field_role
   module:
     - image
-    - options
     - user
 id: user.user.default
 targetEntityType: user
 bundle: user
 mode: default
 content:
+  field_biography:
+    weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
   field_company:
     type: string
     weight: 3
     label: above
     settings:
       link_to_entity: false
-    third_party_settings: {  }
-  field_drupal_contribute:
-    type: list_default
-    weight: 6
-    label: above
-    settings: {  }
     third_party_settings: {  }
   field_first_name:
     weight: 1
@@ -39,12 +41,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
-  field_join_code_sprint:
-    type: list_default
-    weight: 5
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   field_last_name:
     weight: 2
     label: above
@@ -68,7 +64,10 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   member_for:
-    weight: 7
+    weight: 9
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_beginner_workshop: true
+  field_drupal_contribute: true
+  field_join_code_sprint: true

--- a/config/sync/field.field.user.user.field_beginner_workshop.yml
+++ b/config/sync/field.field.user.user.field_beginner_workshop.yml
@@ -12,7 +12,7 @@ field_name: field_beginner_workshop
 entity_type: user
 bundle: user
 label: 'Would you like to join the workshop for beginners?'
-description: 'Requirements to attend the workshop on this page <a href="https://2015.drupalcebu.org/workshops-sessions-for-beginners">https://2015.drupalcebu.org/workshops-sessions-for-beginners.</a>'
+description: 'Requirements to attend the workshop on this page <a href="https://2015.drupalcebu.org/workshops-sessions-for-beginners" target="_blank">https://2015.drupalcebu.org/workshops-sessions-for-beginners.</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.user.user.field_beginner_workshop.yml
+++ b/config/sync/field.field.user.user.field_beginner_workshop.yml
@@ -1,0 +1,21 @@
+uuid: f300b907-e454-4467-8c03-3a8d8d7d944e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_beginner_workshop
+  module:
+    - options
+    - user
+id: user.user.field_beginner_workshop
+field_name: field_beginner_workshop
+entity_type: user
+bundle: user
+label: 'Would you like to join the workshop for beginners?'
+description: 'Requirements to attend the workshop on this page <a href="https://2015.drupalcebu.org/workshops-sessions-for-beginners">https://2015.drupalcebu.org/workshops-sessions-for-beginners.</a>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.user.user.field_biography.yml
+++ b/config/sync/field.field.user.user.field_biography.yml
@@ -1,0 +1,20 @@
+uuid: cefa370b-bb7d-4be2-b009-9b96ff191d78
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_biography
+  module:
+    - user
+id: user.user.field_biography
+field_name: field_biography
+entity_type: user
+bundle: user
+label: Biography
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.user.field_beginner_workshop.yml
+++ b/config/sync/field.storage.user.field_beginner_workshop.yml
@@ -1,0 +1,27 @@
+uuid: 214446c1-dd29-451f-af62-984800934585
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - user
+id: user.field_beginner_workshop
+field_name: field_beginner_workshop
+entity_type: user
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: 'YES'
+      label: 'YES'
+    -
+      value: 'NO'
+      label: 'NO'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.user.field_biography.yml
+++ b/config/sync/field.storage.user.field_biography.yml
@@ -1,0 +1,21 @@
+uuid: 31e30f18-bdeb-4fe9-a800-e74adc6f8674
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_biography
+field_name: field_biography
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.carousel_proposal.yml
+++ b/config/sync/views.view.carousel_proposal.yml
@@ -698,7 +698,7 @@ display:
           element_label_class: ''
           element_label_colon: false
           element_wrapper_type: div
-          element_wrapper_class: 'col-md-9 session-summary'
+          element_wrapper_class: 'col-md-9 topic-summary'
           element_default_classes: false
           empty: ''
           hide_empty: false

--- a/www/themes/custom/drupalcampcebu2015/public/css/style.css
+++ b/www/themes/custom/drupalcampcebu2015/public/css/style.css
@@ -191,44 +191,50 @@ img {
   color: #1664a6;
 }
 
-/* line 41, ../sass/partials/_global.scss */
+/* line 40, ../sass/partials/_global.scss */
+#edit-field-beginner-workshop--description a {
+  color: #fcb040;
+  text-transform: none;
+}
+
+/* line 46, ../sass/partials/_global.scss */
 .region-sidebar ul.menu {
   margin: 0;
 }
-/* line 43, ../sass/partials/_global.scss */
+/* line 48, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li {
   padding: 1.6em;
   padding-top: 2em;
   padding-bottom: 2em;
 }
-/* line 47, ../sass/partials/_global.scss */
+/* line 52, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li a, .region-sidebar ul.menu li p {
   color: white;
   margin-bottom: 0;
   text-transform: uppercase;
 }
 
-/* line 55, ../sass/partials/_global.scss */
+/* line 60, ../sass/partials/_global.scss */
 .region-sidebar li:nth-child(1) {
   background-color: #fcb040;
 }
 
-/* line 58, ../sass/partials/_global.scss */
+/* line 63, ../sass/partials/_global.scss */
 .region-sidebar li:nth-child(2) {
   background-color: #1664a6;
 }
 
-/* line 61, ../sass/partials/_global.scss */
+/* line 66, ../sass/partials/_global.scss */
 .region-sidebar li:nth-child(3) {
   background-color: #89caae;
 }
 
-/* line 64, ../sass/partials/_global.scss */
+/* line 69, ../sass/partials/_global.scss */
 .region-sidebar li:nth-child(4) {
   background-color: #fff;
 }
 
-/* line 68, ../sass/partials/_global.scss */
+/* line 73, ../sass/partials/_global.scss */
 h3 {
   font-size: 1.8em;
   font-weight: 700;
@@ -236,44 +242,44 @@ h3 {
   color: white;
 }
 
-/* line 75, ../sass/partials/_global.scss */
+/* line 80, ../sass/partials/_global.scss */
 a {
   font-size: 1em;
   text-transform: uppercase;
   color: white;
 }
 
-/* line 81, ../sass/partials/_global.scss */
+/* line 86, ../sass/partials/_global.scss */
 a:hover {
   text-decoration: none;
   color: white;
 }
 
-/* line 86, ../sass/partials/_global.scss */
+/* line 91, ../sass/partials/_global.scss */
 p.subtitle {
   text-decoration: underline;
 }
 
 /* Styling for user profile page */
-/* line 92, ../sass/partials/_global.scss */
+/* line 97, ../sass/partials/_global.scss */
 #block-drupalcampcebu2015-page-title h1.page-title {
   font-size: 2em;
   text-align: left;
 }
 
-/* line 99, ../sass/partials/_global.scss */
+/* line 104, ../sass/partials/_global.scss */
 .profile .field--name-field-profile-image {
   width: 35%;
   float: left;
   padding-right: 2em;
 }
-/* line 105, ../sass/partials/_global.scss */
+/* line 110, ../sass/partials/_global.scss */
 .profile .field--name-field-first-name .field__label,
 .profile .field--name-field-last-name .field__label {
   color: #1664a6;
   font-size: 1.1em;
 }
-/* line 111, ../sass/partials/_global.scss */
+/* line 116, ../sass/partials/_global.scss */
 .profile .form-item,
 .profile .form-item h4.label {
   color: #1664a6;
@@ -287,18 +293,18 @@ p.subtitle {
   margin-bottom: 0;
 }
 
-/* line 123, ../sass/partials/_global.scss */
+/* line 128, ../sass/partials/_global.scss */
 #block-views-block-user-proposals-block-user-proposals {
   padding-bottom: 2em;
   padding-top: 0.5em;
   overflow: hidden;
 }
-/* line 127, ../sass/partials/_global.scss */
+/* line 132, ../sass/partials/_global.scss */
 #block-views-block-user-proposals-block-user-proposals h2 {
   margin: 0;
   font-size: 1.2em;
 }
-/* line 131, ../sass/partials/_global.scss */
+/* line 136, ../sass/partials/_global.scss */
 #block-views-block-user-proposals-block-user-proposals a {
   color: #fcb040;
   font-size: 1em;
@@ -307,7 +313,7 @@ p.subtitle {
 }
 
 /* UP Logo below the menu */
-/* line 142, ../sass/partials/_global.scss */
+/* line 147, ../sass/partials/_global.scss */
 #site-wrapper .col-md-4 .up-logo {
   text-align: center;
   padding-top: 1em;
@@ -318,27 +324,27 @@ p.subtitle {
 /* BREAKPOINT SECTION FOR USER PROFILE */
 /* ================== */
 @media only screen and (min-width: 420px) {
-  /* line 156, ../sass/partials/_global.scss */
+  /* line 161, ../sass/partials/_global.scss */
   .profile .field--name-field-first-name .field__label,
   .profile .field--name-field-last-name .field__label {
     font-size: 1.3em;
   }
-  /* line 159, ../sass/partials/_global.scss */
+  /* line 164, ../sass/partials/_global.scss */
   .profile .form-item h4.label {
     font-size: 1.1em;
   }
 
-  /* line 165, ../sass/partials/_global.scss */
+  /* line 170, ../sass/partials/_global.scss */
   #block-views-block-user-proposals-block-user-proposals h2 {
     font-size: 1.7em;
   }
-  /* line 168, ../sass/partials/_global.scss */
+  /* line 173, ../sass/partials/_global.scss */
   #block-views-block-user-proposals-block-user-proposals a {
     font-size: 1.2em;
   }
 }
 @media only screen and (min-width: 1290px) {
-  /* line 179, ../sass/partials/_global.scss */
+  /* line 184, ../sass/partials/_global.scss */
   .profile .field--name-field-first-name .field__label,
   .profile .field--name-field-last-name .field__label,
   .profile .field--name-field-first-name .field__item,
@@ -346,15 +352,15 @@ p.subtitle {
     font-size: 1.5em;
   }
 
-  /* line 184, ../sass/partials/_global.scss */
+  /* line 189, ../sass/partials/_global.scss */
   #block-views-block-user-proposals-block-user-proposals {
     padding-top: 1em;
   }
-  /* line 186, ../sass/partials/_global.scss */
+  /* line 191, ../sass/partials/_global.scss */
   #block-views-block-user-proposals-block-user-proposals h2 {
     font-size: 2em;
   }
-  /* line 189, ../sass/partials/_global.scss */
+  /* line 194, ../sass/partials/_global.scss */
   #block-views-block-user-proposals-block-user-proposals a {
     font-size: 1.5em;
   }

--- a/www/themes/custom/drupalcampcebu2015/public/css/style.css
+++ b/www/themes/custom/drupalcampcebu2015/public/css/style.css
@@ -861,13 +861,15 @@ h6 a,
   font-size: 1.2em;
 }
 
-/* line 99, ../sass/partials/_proposals.scss */
-.view-id-your_proposal ul {
-  list-style-type: none;
+/* line 98, ../sass/partials/_proposals.scss */
+.topic-summary ul {
+  color: #1664a6;
+  font-size: 1.4em;
 }
-/* line 101, ../sass/partials/_proposals.scss */
-.view-id-your_proposal ul li {
-  margin-left: 0;
+
+/* line 103, ../sass/partials/_proposals.scss */
+.item-list ul {
+  color: white;
 }
 
 /* line 109, ../sass/partials/_proposals.scss */

--- a/www/themes/custom/drupalcampcebu2015/public/sass/partials/_global.scss
+++ b/www/themes/custom/drupalcampcebu2015/public/sass/partials/_global.scss
@@ -36,6 +36,11 @@ img {
 .node-type-list dt a {
   color: $color-blue;
 }
+// This is for the link in the description for field 'would you like to join workshop for seminar'.
+#edit-field-beginner-workshop--description a {
+  color: $color-orange;
+  text-transform: none;
+}
 
 // This applies to all menu boxes including sponsor tabs in region sponsors
 .region-sidebar ul.menu {

--- a/www/themes/custom/drupalcampcebu2015/public/sass/partials/_proposals.scss
+++ b/www/themes/custom/drupalcampcebu2015/public/sass/partials/_proposals.scss
@@ -94,15 +94,15 @@ h6,
   }
 }
 
-// Deletes bullets for the unordered list of proposals submitted by the user.
-.view-id-your_proposal {
-  ul {
-    list-style-type: none;
-    li {
-      margin-left: 0;
-    }
+// Styling list in the proposal.
+  .topic-summary ul {
+    color: $color-blue;
+    font-size: 1.4em;
   }
-}
+
+  .item-list ul {
+    color: $color-white-text;
+  }
 
 // Homepage carousel
 #block-views-block-carousel-proposal-block-carousel-proposal {


### PR DESCRIPTION
Add two new fields on user profile; field_biography and field_beginner_workshop.
On user profile page, hide field_beginner_workshop, field_join_code_Sprint, and field_drupal_contribute (These are the fields in question form)
Rearrance fields so in form when creating account, order is in follows;
 -username and password
 -first name
 -last name
 -profile image
 -company
 -role
 -biography
 - would you like to join code sprint on sunday?
 - if yes, have you contributed to drupal before?
 - would you like to join workshop for beginners?
 -timezone
 -language settings
Style link of the description in field_beginner_workshop in global.scss
@Luukyb 