### PR TITLE
Unassign block 'your sessions' to region 'header info top. Ticket #180.

### DIFF
--- a/config/sync/block.block.views_block__your_sessions_block_your_sessions_list.yml
+++ b/config/sync/block.block.views_block__your_sessions_block_your_sessions_list.yml
@@ -1,25 +1,26 @@
 uuid: 6d682bc4-06d6-4f10-a240-6448c7a29dca
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.your_sessions
   module:
     - system
+    - user
     - views
   theme:
     - drupalcampcebu2015
 id: views_block__your_sessions_block_your_sessions_list
 theme: drupalcampcebu2015
-region: header_info_top
-weight: -12
+region: '-1'
+weight: -6
 provider: null
 plugin: 'views_block:your_sessions-block_your_sessions_list'
 settings:
   id: 'views_block:your_sessions-block_your_sessions_list'
   label: ''
   provider: views
-  label_display: visible
+  label_display: '0'
   views_label: ''
   items_per_page: none
 visibility:
@@ -28,3 +29,11 @@ visibility:
     pages: '<front>'
     negate: true
     context_mapping: {  }
+  user_role:
+    id: user_role
+    roles:
+      admin: admin
+      speaker: speaker
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/config/sync/views.view.your_sessions.yml
+++ b/config/sync/views.view.your_sessions.yml
@@ -8,6 +8,7 @@ dependencies:
     - user.role.speaker
   module:
     - node
+    - options
     - user
 id: your_sessions
 label: 'Your Sessions'
@@ -61,14 +62,14 @@ display:
         options:
           grouping: {  }
           row_class: ''
-          default_row_class: true
+          default_row_class: false
           type: ul
           wrapper_class: item-list
           class: ''
       row:
         type: fields
         options:
-          default_field_elements: true
+          default_field_elements: false
           inline: {  }
           separator: ''
           hide_empty: false
@@ -159,6 +160,45 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        field_approved_value:
+          id: field_approved_value
+          table: node__field_approved
+          field: field_approved_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            1: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       sorts:
         created:
           id: created
@@ -175,20 +215,19 @@ display:
           expose:
             label: ''
           granularity: second
-      title: 'Your Sessions'
-      header: {  }
+      title: ''
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          plugin_id: text_custom
       footer: {  }
       empty:
         area_text_custom:
           id: area_text_custom
           table: views
           field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: "<p>You have not submitted a proposal.</p>\n"
           plugin_id: text_custom
       relationships: {  }
       arguments:
@@ -228,6 +267,11 @@ display:
           entity_type: node
           entity_field: uid
           plugin_id: numeric
+        'null':
+          id: 'null'
+          table: views
+          field: 'null'
+          plugin_id: 'null'
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -248,6 +292,61 @@ display:
       display_extenders: {  }
       display_description: ''
       block_description: 'Your sessions'
+      arguments:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
+      defaults:
+        arguments: false
+        header: false
+        empty: false
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: '<h2>Your Sessions</h2>'
+          plugin_id: text_custom
+      block_hide_empty: true
+      empty: {  }
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
We're suppose to hide the block for users without a session submitted or without a speaker or admin role. But we have a user who submitted a session and has a speaker role whose session is not part of the displayed schedule in the site e.g. the training.
'No result behavior doesn't work it still shows the region where it's suppose to be hidden.
@Luukyb 