### PR TITLE
Change drupal assoc link. Ticket #170.

### DIFF
--- a/www/themes/custom/drupalcampcebu2015/templates/page.html.twig
+++ b/www/themes/custom/drupalcampcebu2015/templates/page.html.twig
@@ -76,7 +76,9 @@
 
       <div class="col-md-8">
         {% if page.header_info_top %}
+        <div class="header-info-top">
           {{ page.header_info_top }}
+        </div>
         {% endif %}
 
         {% if is_front %}

--- a/www/themes/custom/drupalcampcebu2015/templates/page.html.twig
+++ b/www/themes/custom/drupalcampcebu2015/templates/page.html.twig
@@ -76,9 +76,7 @@
 
       <div class="col-md-8">
         {% if page.header_info_top %}
-          <div class="header-info-top">
-              {{ page.header_info_top }}
-          </div>
+          {{ page.header_info_top }}
         {% endif %}
 
         {% if is_front %}
@@ -161,7 +159,7 @@
 
 <section class="footer-container">
   <div class="footer-top-text">
-    <a href="https://assoc.drupal.org/help-grow-our-membership">
+    <a href="https://assoc.drupal.org/support-project-you-love" target="_blank">
       <img src="https://assoc.drupal.org/files/Membership_drive_2015_180x150_1_0.png" alt="Membership Logo" title="Membership Logo" class="membership-logo" />
     </a>
     <p>This camp is brought to you by Drupal Cebu User Group.</p>


### PR DESCRIPTION
Change drupal assoc link from https://assoc.drupal.org/help-grow-our-membership to https://assoc.drupal.org/support-project-you-love. Add target=_blank> so it opens on a new tab. Ticket #170.
@Luukyb please review.