### PR TITLE
Add display inline-block for views-row of views sponsors and views sponsors and partners. Ticket #187.

### DIFF
--- a/www/themes/custom/drupalcampcebu2015/public/css/style.css
+++ b/www/themes/custom/drupalcampcebu2015/public/css/style.css
@@ -578,9 +578,11 @@ Temporary fix, display: none. */
   .view-sponsors .views-row,
   .view-sponsors-and-partners-page .views-row {
     text-align: unset;
+    display: inline-block;
+    padding-left: 1em;
   }
 
-  /* line 181, ../sass/partials/_sponsors.scss */
+  /* line 183, ../sass/partials/_sponsors.scss */
   .view-sponsors .view-header,
   .view-sponsors-and-partners-page .view-header,
   .view-sponsors .view-empty,
@@ -591,7 +593,7 @@ Temporary fix, display: none. */
     float: none;
   }
 
-  /* line 190, ../sass/partials/_sponsors.scss */
+  /* line 192, ../sass/partials/_sponsors.scss */
   .view-sponsors .view-empty,
   .view-sponsors-and-partners-page .view-empty,
   .view-sponsors .view-content,
@@ -599,27 +601,27 @@ Temporary fix, display: none. */
     vertical-align: middle;
   }
 
-  /* line 194, ../sass/partials/_sponsors.scss */
+  /* line 196, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .view-empty a {
     display: inline-block;
   }
 
-  /* line 198, ../sass/partials/_sponsors.scss */
+  /* line 200, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .sponsor-header {
     padding: 3em 1.6em;
   }
 }
-/* line 203, ../sass/partials/_sponsors.scss */
+/* line 205, ../sass/partials/_sponsors.scss */
 .col-md-8.camp-button-wrapper {
   float: right;
   margin-top: 1em;
 }
 
-/* line 209, ../sass/partials/_sponsors.scss */
+/* line 211, ../sass/partials/_sponsors.scss */
 .view-footer li p {
   margin-bottom: 0;
 }
-/* line 212, ../sass/partials/_sponsors.scss */
+/* line 214, ../sass/partials/_sponsors.scss */
 .view-footer li::before {
   display: none;
 }

--- a/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
+++ b/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
@@ -170,6 +170,8 @@ Temporary fix, display: none. */
     width: 100%;
     .views-row {
       text-align: unset;
+      display: inline-block;
+      padding-left: 1em;
     }
   }
 


### PR DESCRIPTION
Logos should not be displayed on top of each other. With our PSD file, logos are inline on big resolution starting tablet landscape.
Add display inline-block for views-row of views sponsors and views sponsors and partners
@Luukyb 