### PR TITLE
Features 165 sponsor links.

### DIFF
--- a/config/sync/core.entity_form_display.node.sponsors.default.yml
+++ b/config/sync/core.entity_form_display.node.sponsors.default.yml
@@ -3,11 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.sponsors.field_sponsor_link
     - field.field.node.sponsors.field_sponsor_logo
     - field.field.node.sponsors.field_sponsor_type
     - node.type.sponsors
   module:
     - image
+    - link
+    - path
 id: node.sponsors.default
 targetEntityType: node
 bundle: sponsors
@@ -18,6 +21,13 @@ content:
     weight: 10
     settings: {  }
     third_party_settings: {  }
+  field_sponsor_link:
+    weight: 31
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
   field_sponsor_logo:
     weight: 26
     settings:
@@ -33,6 +43,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
   promote:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_view_display.node.sponsors.default.yml
+++ b/config/sync/core.entity_view_display.node.sponsors.default.yml
@@ -3,17 +3,30 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.sponsors.field_sponsor_link
     - field.field.node.sponsors.field_sponsor_logo
     - field.field.node.sponsors.field_sponsor_type
     - node.type.sponsors
   module:
     - image
+    - link
     - user
 id: node.sponsors.default
 targetEntityType: node
 bundle: sponsors
 mode: default
 content:
+  field_sponsor_link:
+    weight: 103
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
   field_sponsor_logo:
     weight: 101
     label: above

--- a/config/sync/field.field.node.sponsors.field_sponsor_link.yml
+++ b/config/sync/field.field.node.sponsors.field_sponsor_link.yml
@@ -1,0 +1,23 @@
+uuid: bace5d3e-bd0d-4510-8b08-8b8858adecdc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sponsor_link
+    - node.type.sponsors
+  module:
+    - link
+id: node.sponsors.field_sponsor_link
+field_name: field_sponsor_link
+entity_type: node
+bundle: sponsors
+label: 'Sponsor link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/sync/field.storage.node.field_sponsor_link.yml
+++ b/config/sync/field.storage.node.field_sponsor_link.yml
@@ -1,0 +1,19 @@
+uuid: b2ba6e32-ce74-4f29-b058-88f67957715d
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_sponsor_link
+field_name: field_sponsor_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.sponsor_link.yml
+++ b/config/sync/views.view.sponsor_link.yml
@@ -9,9 +9,11 @@ dependencies:
     - user.role.authenticated
     - user.role.speaker
   content:
+    - 'taxonomy_term:sponsor_type:8c3e419e-3710-462d-af00-ddf6d3ec574a'
+    - 'taxonomy_term:sponsor_type:a6d56173-c6b1-4dff-9c06-6dc957c9fa03'
     - 'taxonomy_term:sponsor_type:bb0eadc2-8c2a-473b-bf00-c025af324ee4'
     - 'taxonomy_term:sponsor_type:e21b3019-331d-40df-9800-d395a96011c6'
-    - 'taxonomy_term:sponsor_type:efc345c7-1ab7-49da-9900-008f32b5c4d5'
+    - 'taxonomy_term:sponsor_type:f17548ce-7853-4d69-bf00-da1709e7960b'
   module:
     - link
     - node
@@ -197,7 +199,7 @@ display:
           admin_label: ''
           operator: or
           value:
-            1: 1
+            6: 6
           group: 1
           exposed: false
           expose:
@@ -374,6 +376,134 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_sponsor_link'
+  block_link_code_sprint:
+    display_plugin: block
+    id: block_link_code_sprint
+    display_title: 'Block Link Code Sprint'
+    position: 4
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      block_description: 'Block Link Code Sprint'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_link_coffee_snacks:
+    display_plugin: block
+    id: block_link_coffee_snacks
+    display_title: 'Block Link Coffee and Snacks'
+    position: 5
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      block_description: 'Block Link Coffee and Snacks'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: true
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        field_sponsor_type_target_id:
+          id: field_sponsor_type_target_id
+          table: node__field_sponsor_type
+          field: field_sponsor_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            8: 8
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sponsor_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
   block_link_gold:
     display_plugin: block
     id: block_link_gold
@@ -384,6 +514,153 @@ display:
       defaults:
         fields: true
       display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_link_partners:
+    display_plugin: block
+    id: block_link_partners
+    display_title: 'Block Link Partners'
+    position: 6
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      block_description: 'Block Link Partners'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: true
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        field_sponsor_type_target_id:
+          id: field_sponsor_type_target_id
+          table: node__field_sponsor_type
+          field: field_sponsor_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            7: 7
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sponsor_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_link_saturday_lunch:
+    display_plugin: block
+    id: block_link_saturday_lunch
+    display_title: 'Block Link Saturday Lunch'
+    position: 7
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      block_description: 'Block Link Saturday Lunch'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_link_saturday_night:
+    display_plugin: block
+    id: block_link_saturday_night
+    display_title: 'Block Link Saturday Night'
+    position: 8
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      block_description: 'Block Link Saturday Night'
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.sponsor_link.yml
+++ b/config/sync/views.view.sponsor_link.yml
@@ -9,6 +9,8 @@ dependencies:
     - user.role.authenticated
     - user.role.speaker
   content:
+    - 'taxonomy_term:sponsor_type:bb0eadc2-8c2a-473b-bf00-c025af324ee4'
+    - 'taxonomy_term:sponsor_type:e21b3019-331d-40df-9800-d395a96011c6'
     - 'taxonomy_term:sponsor_type:efc345c7-1ab7-49da-9900-008f32b5c4d5'
   module:
     - link
@@ -61,10 +63,17 @@ display:
       pager:
         type: some
         options:
-          items_per_page: 1
+          items_per_page: 0
           offset: 0
       style:
-        type: default
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
       row:
         type: fields
         options:
@@ -77,19 +86,108 @@ display:
           id: field_sponsor_link
           table: node__field_sponsor_link
           field: field_sponsor_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: '0'
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
           plugin_id: field
       filters:
         status:
-          value: true
+          id: status
           table: node_field_data
           field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: true
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
           plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
-          expose:
-            operator: ''
-          group: 1
         field_sponsor_type_target_id:
           id: field_sponsor_type_target_id
           table: node__field_sponsor_type
@@ -167,13 +265,104 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_sponsor_link'
-  attachment_gold_link:
-    display_plugin: attachment
-    id: attachment_gold_link
-    display_title: 'Gold link'
-    position: 2
+  block_link_bronze:
+    display_plugin: block
+    id: block_link_bronze
+    display_title: 'Block Link Bronze'
+    position: 3
     display_options:
       display_extenders: {  }
+      block_description: 'Block Link Bronze'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: true
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        field_sponsor_type_target_id:
+          id: field_sponsor_type_target_id
+          table: node__field_sponsor_type
+          field: field_sponsor_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            3: 3
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sponsor_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       display_description: ''
     cache_metadata:
       max-age: -1
@@ -185,84 +374,124 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.node.field_sponsor_link'
-  block_sponsor_link:
+  block_link_gold:
     display_plugin: block
-    id: block_sponsor_link
-    display_title: 'Sponsor link'
+    id: block_link_gold
+    display_title: 'Block Link Gold'
     position: 1
     display_options:
       display_extenders: {  }
-      fields:
-        field_sponsor_link:
-          id: field_sponsor_link
-          table: node__field_sponsor_link
-          field: field_sponsor_link
+      defaults:
+        fields: true
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_link_silver:
+    display_plugin: block
+    id: block_link_silver
+    display_title: 'Block Link Silver'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
           relationship: none
           group_type: group
           admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: '0'
-          element_class: ''
-          element_label_type: '0'
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: '0'
-          element_wrapper_class: ''
-          element_default_classes: false
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: uri
-          type: link
-          settings:
-            trim_length: 80
-            url_only: false
-            url_plain: false
-            rel: '0'
-            target: '0'
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
+          operator: '='
+          value: true
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        field_sponsor_type_target_id:
+          id: field_sponsor_type_target_id
+          table: node__field_sponsor_type
+          field: field_sponsor_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            2: 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sponsor_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       defaults:
-        fields: false
-      display_description: ''
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.sponsor_link.yml
+++ b/config/sync/views.view.sponsor_link.yml
@@ -1,0 +1,275 @@
+uuid: a8580c89-dbf8-40f0-8c00-ecd1407925d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sponsor_link
+    - taxonomy.vocabulary.sponsor_type
+    - user.role.admin
+    - user.role.authenticated
+    - user.role.speaker
+  content:
+    - 'taxonomy_term:sponsor_type:efc345c7-1ab7-49da-9900-008f32b5c4d5'
+  module:
+    - link
+    - node
+    - taxonomy
+    - user
+id: sponsor_link
+label: 'Sponsor link'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
+            admin: admin
+            speaker: speaker
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 1
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        field_sponsor_link:
+          id: field_sponsor_link
+          table: node__field_sponsor_link
+          field: field_sponsor_link
+          plugin_id: field
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_sponsor_type_target_id:
+          id: field_sponsor_type_target_id
+          table: node__field_sponsor_type
+          field: field_sponsor_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            1: 1
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sponsor_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: ''
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  attachment_gold_link:
+    display_plugin: attachment
+    id: attachment_gold_link
+    display_title: 'Gold link'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'
+  block_sponsor_link:
+    display_plugin: block
+    id: block_sponsor_link
+    display_title: 'Sponsor link'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      fields:
+        field_sponsor_link:
+          id: field_sponsor_link
+          table: node__field_sponsor_link
+          field: field_sponsor_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: '0'
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      defaults:
+        fields: false
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.node.field_sponsor_link'

--- a/config/sync/views.view.sponsors.yml
+++ b/config/sync/views.view.sponsors.yml
@@ -111,14 +111,14 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: '0'
           element_class: ''
-          element_label_type: ''
+          element_label_type: '0'
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
+          element_wrapper_type: '0'
           element_wrapper_class: ''
-          element_default_classes: true
+          element_default_classes: false
           empty: ''
           hide_empty: false
           empty_zero: false
@@ -126,7 +126,7 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
+            image_style: drupalcampcebu_big
             image_link: ''
           group_column: ''
           group_columns: {  }
@@ -218,6 +218,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_bronze'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false
@@ -391,71 +402,6 @@ display:
       display_extenders: {  }
       display_description: ''
       block_description: 'Gold sponsor'
-      fields:
-        field_sponsor_logo:
-          id: field_sponsor_logo
-          table: node__field_sponsor_logo
-          field: field_sponsor_logo
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: '0'
-          element_class: ''
-          element_label_type: '0'
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: '0'
-          element_wrapper_class: ''
-          element_default_classes: false
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: image
-          settings:
-            image_style: drupalcampcebu_big
-            image_link: content
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
       defaults:
         fields: false
         filters: false
@@ -555,10 +501,75 @@ display:
           group_type: group
           admin_label: ''
           empty: false
-          view_to_insert: 'sponsor_link:attachment_gold_link'
+          view_to_insert: 'sponsor_link:block_link_gold'
           inherit_arguments: false
           plugin_id: view
       css_class: ''
+      fields:
+        field_sponsor_logo:
+          id: field_sponsor_logo
+          table: node__field_sponsor_logo
+          field: field_sponsor_logo
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: '0'
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: drupalcampcebu_big
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -590,6 +601,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n</div>\n"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_silver'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false

--- a/config/sync/views.view.sponsors.yml
+++ b/config/sync/views.view.sponsors.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_sponsor_logo
     - node.type.sponsors
     - taxonomy.vocabulary.sponsor_type
+    - views.view.sponsor_link
   content:
     - 'taxonomy_term:sponsor_type:bb0eadc2-8c2a-473b-bf00-c025af324ee4'
     - 'taxonomy_term:sponsor_type:e21b3019-331d-40df-9800-d395a96011c6'
@@ -215,7 +216,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n</div>"
           plugin_id: text_custom
       defaults:
         header: false
@@ -443,7 +444,7 @@ display:
           type: image
           settings:
             image_style: drupalcampcebu_big
-            image_link: ''
+            image_link: content
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -544,8 +545,19 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n   <h3>Gold Sponsor</h3>\n   <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n   <h3>Gold Sponsor</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:attachment_gold_link'
+          inherit_arguments: false
+          plugin_id: view
       css_class: ''
     cache_metadata:
       max-age: -1
@@ -576,7 +588,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>\n"
+          content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n</div>\n"
           plugin_id: text_custom
       defaults:
         header: false

--- a/config/sync/views.view.sponsors_and_partners_page.yml
+++ b/config/sync/views.view.sponsors_and_partners_page.yml
@@ -6,9 +6,10 @@ dependencies:
     - field.storage.node.field_sponsor_logo
     - node.type.sponsors
     - taxonomy.vocabulary.sponsor_type
+    - views.view.sponsor_link
   content:
     - 'taxonomy_term:sponsor_type:1740c0c1-3cb4-4b8d-a302-2f2cdf22105b'
-    - 'taxonomy_term:sponsor_type:2b232a24-2ba2-4c2f-9807-7f8658fbcbac'
+    - 'taxonomy_term:sponsor_type:8c3e419e-3710-462d-af00-ddf6d3ec574a'
     - 'taxonomy_term:sponsor_type:a6d56173-c6b1-4dff-9c06-6dc957c9fa03'
     - 'taxonomy_term:sponsor_type:bb0eadc2-8c2a-473b-bf00-c025af324ee4'
     - 'taxonomy_term:sponsor_type:e21b3019-331d-40df-9800-d395a96011c6'
@@ -246,7 +247,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Code Sprint Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Code Sprint Sponsors</h3>\n</div>"
           plugin_id: text_custom
       defaults:
         header: false
@@ -536,7 +537,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Coffee and Snacks sponsor</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Coffee and Snacks sponsor</h3>\n</div>"
           plugin_id: text_custom
       empty:
         area_text_custom:
@@ -579,7 +580,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Partners</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Partners</h3>\n</div>"
           plugin_id: text_custom
       defaults:
         header: false
@@ -869,7 +870,7 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Saturday Night sponsor</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Saturday Night sponsor</h3>\n</div>"
           plugin_id: text_custom
       empty: {  }
     cache_metadata:
@@ -901,7 +902,7 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Saturday Lunch Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Saturday Lunch Sponsors</h3>\n</div>"
           plugin_id: text_custom
       defaults:
         header: false
@@ -1075,7 +1076,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n</div>"
           plugin_id: text_custom
       defaults:
         header: false
@@ -1404,8 +1405,19 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n   <h3>Gold Sponsor</h3>\n   <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>"
+          content: "<div class=\"sponsor-header\">\n   <h3>Gold Sponsor</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_gold'
+          inherit_arguments: false
+          plugin_id: view
       css_class: ''
     cache_metadata:
       max-age: -1
@@ -1436,7 +1448,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n  <p class=\"subtitle\"><a href=\"mailto:drupalcebu@gmail.com\">Sponsor Now</a></p>\n</div>\n"
+          content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n</div>\n"
           plugin_id: text_custom
       defaults:
         header: false

--- a/config/sync/views.view.sponsors_and_partners_page.yml
+++ b/config/sync/views.view.sponsors_and_partners_page.yml
@@ -249,6 +249,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Code Sprint Sponsors</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_code_sprint'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false
@@ -539,6 +550,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Coffee and Snacks sponsor</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_coffee_snacks'
+          inherit_arguments: false
+          plugin_id: view
       empty:
         area_text_custom:
           id: area_text_custom
@@ -582,6 +604,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Partners</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_partners'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false
@@ -1078,6 +1111,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Bronze Sponsors</h3>\n</div>"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_bronze'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false
@@ -1450,6 +1494,17 @@ display:
           tokenize: false
           content: "<div class=\"sponsor-header\">\n  <h3>Silver Sponsors</h3>\n</div>\n"
           plugin_id: text_custom
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'sponsor_link:block_link_silver'
+          inherit_arguments: false
+          plugin_id: view
       defaults:
         header: false
         empty: false

--- a/www/themes/custom/drupalcampcebu2015/public/css/style.css
+++ b/www/themes/custom/drupalcampcebu2015/public/css/style.css
@@ -18,10 +18,10 @@
   background-color: #1664a6;
   padding: 1.5em;
 }
-/* line 14, ../sass/partials/_header.scss */
+/* line 13, ../sass/partials/_header.scss */
 .header-info-top p,
 .header-info-top h2 {
-  color: white;
+  color: #fff;
   text-transform: uppercase;
   font-family: "Montserrat", sans-serif;
   font-size: 1.1em;
@@ -38,7 +38,7 @@
   text-align: center;
 }
 
-/* line 35, ../sass/partials/_header.scss */
+/* line 34, ../sass/partials/_header.scss */
 .content h1,
 .content h2,
 .region-header-info-bottom h1,
@@ -109,7 +109,7 @@
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-4 {
   padding: 0;
 }
-/* line 22, ../sass/partials/_newsletter.scss */
+/* line 21, ../sass/partials/_newsletter.scss */
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-3,
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-8 {
   padding-left: 0;
@@ -120,7 +120,7 @@
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-8 label {
   font-weight: normal;
 }
-/* line 34, ../sass/partials/_newsletter.scss */
+/* line 33, ../sass/partials/_newsletter.scss */
 .newsletter .email-address,
 .newsletter .firstname {
   color: #fcb040;
@@ -140,7 +140,7 @@
   padding: 0.3em;
   width: 100%;
   margin-top: 0.5em;
-  color: white;
+  color: #fff;
   background-color: #fcb040;
   border: none;
   text-transform: uppercase;
@@ -166,7 +166,7 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1.8em;
   font-weight: 700;
   margin: 0;
-  color: white;
+  color: #fff;
 }
 
 /* line 20, ../sass/partials/_global.scss */
@@ -235,7 +235,7 @@ img {
 }
 /* line 75, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(1) a, .region-sidebar ul.menu li:nth-child(1) p, .region-sidebar ul.menu li:nth-child(1) h3 {
-  color: white;
+  color: #fff;
 }
 
 /* line 82, ../sass/partials/_global.scss */
@@ -244,7 +244,7 @@ img {
 }
 /* line 84, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(2) a, .region-sidebar ul.menu li:nth-child(2) p, .region-sidebar ul.menu li:nth-child(2) h3 {
-  color: white;
+  color: #fff;
 }
 
 /* line 91, ../sass/partials/_global.scss */
@@ -253,7 +253,7 @@ img {
 }
 /* line 93, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(3) a, .region-sidebar ul.menu li:nth-child(3) p, .region-sidebar ul.menu li:nth-child(3) h3 {
-  color: white;
+  color: #fff;
 }
 
 /* line 99, ../sass/partials/_global.scss */
@@ -270,11 +270,11 @@ a:hover {
 
 /* line 109, ../sass/partials/_global.scss */
 .header-info-top a {
-  color: white;
+  color: #fff;
 }
 /* line 112, ../sass/partials/_global.scss */
 .header-info-top a:hover {
-  color: white;
+  color: #fff;
 }
 
 /* line 117, ../sass/partials/_global.scss */
@@ -297,13 +297,13 @@ p.subtitle {
   float: left;
   padding-right: 2em;
 }
-/* line 138, ../sass/partials/_global.scss */
+/* line 137, ../sass/partials/_global.scss */
 .profile .field__label,
 .profile .field__item {
   color: #1664a6;
   font-size: 1.1em;
 }
-/* line 144, ../sass/partials/_global.scss */
+/* line 143, ../sass/partials/_global.scss */
 .profile .form-item,
 .profile .form-item h4.label {
   color: #1664a6;
@@ -348,7 +348,7 @@ p.subtitle {
 /* BREAKPOINT SECTION FOR USER PROFILE */
 /* ================== */
 @media only screen and (min-width: 420px) {
-  /* line 190, ../sass/partials/_global.scss */
+  /* line 189, ../sass/partials/_global.scss */
   .profile .field__label,
   .profile .field__item {
     font-size: 1.3em;
@@ -368,7 +368,7 @@ p.subtitle {
   }
 }
 @media only screen and (min-width: 1290px) {
-  /* line 211, ../sass/partials/_global.scss */
+  /* line 210, ../sass/partials/_global.scss */
   .profile .field__label,
   .profile .field__item {
     font-size: 1.5em;
@@ -400,7 +400,7 @@ p.subtitle {
 .promote-sponsor-tab p:nth-child(2) {
   font-size: 1.5em;
 }
-/* line 12, ../sass/partials/_sponsors.scss */
+/* line 11, ../sass/partials/_sponsors.scss */
 .promote-sponsor-tab p:nth-child(1),
 .promote-sponsor-tab p:nth-child(2) {
   color: #1664a6;
@@ -412,7 +412,7 @@ p.subtitle {
   color: #1664a6;
 }
 
-/* line 23, ../sass/partials/_sponsors.scss */
+/* line 22, ../sass/partials/_sponsors.scss */
 .view-sponsors,
 .view-sponsors-and-partners-page {
   overflow: hidden;
@@ -421,91 +421,33 @@ p.subtitle {
 /* line 25, ../sass/partials/_sponsors.scss */
 .view-sponsors .views-row,
 .view-sponsors-and-partners-page .views-row {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 0.5em;
+  padding-bottom: 1.5em;
   text-align: center;
 }
 
-/* Sponsor header background */
-/* line 34, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-block-sponsor-gold,
-#block-views-block-sponsors-and-partners-page-block-sponsor-gold {
-  overflow: hidden;
-}
-/* line 36, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-block-sponsor-gold .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-sponsor-gold .sponsor-header {
-  background-color: #fcb040;
-}
-
-/* line 44, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-block-sponsor-silver .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-sponsor-silver .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-partners .sponsor-header {
-  background-color: #1664a6;
-}
-
-/* line 55, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-block-sponsor-bronze .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-sponsor-bronze .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-code-sprint .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-coffee .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-saturday-lunch .sponsor-header,
-#block-views-block-sponsors-and-partners-page-block-sat-night .sponsor-header {
-  background-color: #89caae;
-}
-
-/* line 64, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-and-partners-page-block-code-sprint,
-#block-views-block-sponsors-and-partners-page-block-coffee,
-#block-views-block-sponsors-and-partners-page-block-saturday-lunch,
-#block-views-block-sponsors-and-partners-page-block-sat-night,
-#block-views-block-sponsors-and-partners-page-block-partners {
-  margin-top: 1.2em;
-}
-
-/* line 68, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-block-sponsor-promote .sponsor-header {
-  padding: 3em 1.6em 1em;
-}
-
-/* View should be hidden without content, but view still showing in the markup.
-Temporary fix, display: none. */
-/* line 75, ../sass/partials/_sponsors.scss */
-#block-views-block-sponsors-and-partners-page-block-saturday-lunch,
-#block-views-block-sponsors-and-partners-page-block-sat-night {
-  display: none;
-}
-
-/* 'See all sponsors' button displayed except on /sponsors page. */
-/* line 80, ../sass/partials/_sponsors.scss */
-.path-sponsors .all-sponsor-button {
-  display: none;
-}
-
 /* Sponsor header text */
-/* line 85, ../sass/partials/_sponsors.scss */
+/* line 33, ../sass/partials/_sponsors.scss */
 .sponsor-header {
-  padding: 3em 1.6em;
   /* Possible fix for the bug in sponsor tabs background-color */
 }
-/* line 90, ../sass/partials/_sponsors.scss */
+/* line 35, ../sass/partials/_sponsors.scss */
 .sponsor-header a,
 .sponsor-header h3 {
   color: #fff;
 }
-/* line 93, ../sass/partials/_sponsors.scss */
+/* line 39, ../sass/partials/_sponsors.scss */
 .sponsor-header h3 {
   font-size: 1.8em;
   font-weight: 700;
   margin: 0;
 }
-/* line 98, ../sass/partials/_sponsors.scss */
+/* line 44, ../sass/partials/_sponsors.scss */
 .sponsor-header a {
   font-size: 1.3em;
   text-transform: uppercase;
 }
-/* line 102, ../sass/partials/_sponsors.scss */
+/* line 48, ../sass/partials/_sponsors.scss */
 .sponsor-header:before {
   background-color: inherit;
   height: 100%;
@@ -517,7 +459,104 @@ Temporary fix, display: none. */
   z-index: -1;
 }
 
-/* line 114, ../sass/partials/_sponsors.scss */
+/* line 61, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-header.col-md-4, .view-id-sponsors_and_partners_page .view-header.col-md-4 {
+  float: left;
+  width: 100%;
+}
+/* line 65, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-header.col-md-4 h3, .view-id-sponsors_and_partners_page .view-header.col-md-4 h3 {
+  padding-top: 1em;
+  text-align: center;
+}
+/* line 70, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-content.col-md-4, .view-id-sponsors_and_partners_page .view-content.col-md-4 {
+  float: right;
+}
+/* line 73, ../sass/partials/_sponsors.scss */
+.view-id-sponsors a, .view-id-sponsors_and_partners_page a {
+  color: #fff;
+  text-decoration: underline;
+  text-transform: uppercase;
+}
+
+/* line 80, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content,
+.view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content {
+  width: 100%;
+}
+/* line 83, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul,
+.view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul {
+  list-style: none;
+  margin-top: 0.5em;
+  text-align: center;
+}
+/* line 87, ../sass/partials/_sponsors.scss */
+.view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul li,
+.view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul li {
+  margin: 0;
+  margin-left: 2em;
+  margin-right: 2em;
+}
+
+/* line 97, ../sass/partials/_sponsors.scss */
+.view-display-id-block_sponsor_gold .view-header.col-md-4 .sponsor-header,
+.view-display-id-block_sponsor_gold .view-header.col-md-4 .view-id-sponsor_link .view-content {
+  background-color: #fcb040;
+}
+
+/* line 106, ../sass/partials/_sponsors.scss */
+#block-views-block-sponsors-block-sponsor-silver .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-sponsor-silver .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-partners .sponsor-header {
+  background-color: #1664a6;
+}
+
+/* line 117, ../sass/partials/_sponsors.scss */
+#block-views-block-sponsors-block-sponsor-bronze .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-sponsor-bronze .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-code-sprint .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-coffee .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-saturday-lunch .sponsor-header,
+#block-views-block-sponsors-and-partners-page-block-sat-night .sponsor-header {
+  background-color: #89caae;
+}
+
+/* line 122, ../sass/partials/_sponsors.scss */
+#block-views-block-sponsors-and-partners-page-block-code-sprint,
+#block-views-block-sponsors-and-partners-page-block-coffee,
+#block-views-block-sponsors-and-partners-page-block-saturday-lunch,
+#block-views-block-sponsors-and-partners-page-block-sat-night,
+#block-views-block-sponsors-and-partners-page-block-partners {
+  margin-top: 1.2em;
+}
+
+/* line 130, ../sass/partials/_sponsors.scss */
+#block-views-block-sponsors-block-sponsor-promote .sponsor-header {
+  padding: 3em 1.6em 1em;
+}
+
+/* line 135, ../sass/partials/_sponsors.scss */
+.view-id-sponsor_link .view-content {
+  float: left;
+}
+
+/* View should be hidden without content, but view still showing in the markup.
+Temporary fix, display: none. */
+/* line 142, ../sass/partials/_sponsors.scss */
+#block-views-block-sponsors-and-partners-page-block-saturday-lunch,
+#block-views-block-sponsors-and-partners-page-block-sat-night {
+  display: none;
+}
+
+/* 'See all sponsors' button displayed except on /sponsors page. */
+/* line 148, ../sass/partials/_sponsors.scss */
+.path-sponsors .all-sponsor-button {
+  display: none;
+}
+
+/* line 152, ../sass/partials/_sponsors.scss */
 .region-sponsors .view-empty a {
   color: #fff;
   display: block;
@@ -528,13 +567,13 @@ Temporary fix, display: none. */
   margin: 15px 0;
 }
 
-/* line 125, ../sass/partials/_sponsors.scss */
+/* line 163, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-gold .view-empty a {
   background-color: #fcb040;
   font-size: 1.6em;
 }
 
-/* line 134, ../sass/partials/_sponsors.scss */
+/* line 172, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-silver
 #block-views-block-sponsors-and-partners-page-block-sponsor-silver .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-partners .view-empty a {
@@ -542,7 +581,7 @@ Temporary fix, display: none. */
   font-size: 1.4em;
 }
 
-/* line 146, ../sass/partials/_sponsors.scss */
+/* line 184, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-bronze .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-sponsor-bronze .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-code-sprint .view-empty a,
@@ -553,10 +592,10 @@ Temporary fix, display: none. */
   font-size: 1.3em;
 }
 
-/* line 152, ../sass/partials/_sponsors.scss */
+/* line 190, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-promote .view-empty a {
   background-color: #fcb040;
-  color: white;
+  color: #fff;
   font-size: 1.5em;
   height: auto;
   padding: 20px;
@@ -568,32 +607,57 @@ Temporary fix, display: none. */
 /* ================== */
 /* Sponsor override float into table display to center items */
 @media (min-width: 992px) {
-  /* line 168, ../sass/partials/_sponsors.scss */
+  /* line 205, ../sass/partials/_sponsors.scss */
   .view-sponsors,
   .view-sponsors-and-partners-page {
-    display: table;
     width: 100%;
   }
-  /* line 171, ../sass/partials/_sponsors.scss */
+  /* line 208, ../sass/partials/_sponsors.scss */
   .view-sponsors .views-row,
   .view-sponsors-and-partners-page .views-row {
-    text-align: unset;
+    text-align: left;
     display: inline-block;
     padding-left: 1em;
   }
 
-  /* line 183, ../sass/partials/_sponsors.scss */
-  .view-sponsors .view-header,
-  .view-sponsors-and-partners-page .view-header,
-  .view-sponsors .view-empty,
-  .view-sponsors-and-partners-page .view-empty,
-  .view-sponsors .view-content,
-  .view-sponsors-and-partners-page .view-content {
-    display: table-cell;
-    float: none;
+  /* line 215, ../sass/partials/_sponsors.scss */
+  .sponsor-header {
+    padding-top: 3em;
+    padding-left: 1.6em;
   }
 
-  /* line 192, ../sass/partials/_sponsors.scss */
+  /* line 221, ../sass/partials/_sponsors.scss */
+  .view-id-sponsors .view-header.col-md-4, .view-id-sponsors_and_partners_page .view-header.col-md-4 {
+    width: 33.33333333%;
+  }
+  /* line 224, ../sass/partials/_sponsors.scss */
+  .view-id-sponsors .view-header.col-md-4 h3, .view-id-sponsors_and_partners_page .view-header.col-md-4 h3 {
+    text-align: left;
+  }
+  /* line 227, ../sass/partials/_sponsors.scss */
+  .view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul, .view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul {
+    text-align: left;
+  }
+
+  /* line 234, ../sass/partials/_sponsors.scss */
+  .view-sponsor-link.view-id-sponsor_link {
+    min-height: 11em;
+    overflow: hidden;
+  }
+
+  /* line 239, ../sass/partials/_sponsors.scss */
+  .view-sponsor-link.view-display-id-block_link_silver {
+    min-height: 9em;
+    overflow: hidden;
+  }
+
+  /* line 243, ../sass/partials/_sponsors.scss */
+  .view-sponsor-link.view-display-id-block_link_bronze {
+    min-height: 7em;
+    overflow: hidden;
+  }
+
+  /* line 249, ../sass/partials/_sponsors.scss */
   .view-sponsors .view-empty,
   .view-sponsors-and-partners-page .view-empty,
   .view-sponsors .view-content,
@@ -601,27 +665,27 @@ Temporary fix, display: none. */
     vertical-align: middle;
   }
 
-  /* line 196, ../sass/partials/_sponsors.scss */
+  /* line 256, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .view-empty a {
     display: inline-block;
   }
 
-  /* line 200, ../sass/partials/_sponsors.scss */
+  /* line 260, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .sponsor-header {
     padding: 3em 1.6em;
   }
 }
-/* line 205, ../sass/partials/_sponsors.scss */
+/* line 265, ../sass/partials/_sponsors.scss */
 .col-md-8.camp-button-wrapper {
   float: right;
   margin-top: 1em;
 }
 
-/* line 211, ../sass/partials/_sponsors.scss */
+/* line 271, ../sass/partials/_sponsors.scss */
 .view-footer li p {
   margin-bottom: 0;
 }
-/* line 214, ../sass/partials/_sponsors.scss */
+/* line 274, ../sass/partials/_sponsors.scss */
 .view-footer li::before {
   display: none;
 }
@@ -641,12 +705,12 @@ Temporary fix, display: none. */
 .footer-container img.membership-logo {
   padding: 0 0 16px;
 }
-/* line 14, ../sass/partials/_footer.scss */
+/* line 13, ../sass/partials/_footer.scss */
 .footer-container div:nth-child(1),
 .footer-container div:nth-child(2) {
   text-align: center;
   font-size: 0.8em;
-  color: white;
+  color: #fff;
   font-family: "Open Sans", sans-serif;
   padding-bottom: 0.5em;
   font-weight: 300;
@@ -654,7 +718,7 @@ Temporary fix, display: none. */
 /* line 21, ../sass/partials/_footer.scss */
 .footer-container div:nth-child(1) p a,
 .footer-container div:nth-child(2) p a {
-  color: white;
+  color: #fff;
 }
 
 @media only screen and (min-width: 420px) {
@@ -662,7 +726,7 @@ Temporary fix, display: none. */
   #site-wrapper .site-logo {
     margin-bottom: 2.5em;
   }
-  /* line 8, ../sass/partials/_media-queries.scss */
+  /* line 7, ../sass/partials/_media-queries.scss */
   #site-wrapper .header-info-top,
   #site-wrapper .header-info-bottom {
     text-align: left;
@@ -670,7 +734,7 @@ Temporary fix, display: none. */
     padding-top: 3.5em;
     padding-bottom: 5.5em;
   }
-  /* line 11, ../sass/partials/_media-queries.scss */
+  /* line 10, ../sass/partials/_media-queries.scss */
   #site-wrapper .header-info-top h3,
   #site-wrapper .header-info-top p,
   #site-wrapper .header-info-bottom h3,
@@ -698,7 +762,7 @@ Temporary fix, display: none. */
     font-size: 2.1em;
     margin-top: 1.5em;
   }
-  /* line 39, ../sass/partials/_media-queries.scss */
+  /* line 38, ../sass/partials/_media-queries.scss */
   #site-wrapper .newsletter .email-address,
   #site-wrapper .newsletter .firstname {
     font-size: 1.5em;
@@ -748,7 +812,7 @@ Temporary fix, display: none. */
   }
 }
 @media only screen and (min-width: 1290px) {
-  /* line 87, ../sass/partials/_media-queries.scss */
+  /* line 86, ../sass/partials/_media-queries.scss */
   .header-info-top h3,
   .header-info-top p {
     font-size: 1.2em;
@@ -773,7 +837,7 @@ h1 {
   text-align: left;
 }
 
-/* line 9, ../sass/partials/_proposals.scss */
+/* line 8, ../sass/partials/_proposals.scss */
 h6,
 .speaker-announcement {
   color: #1664a6;
@@ -800,7 +864,7 @@ h6 a,
   text-decoration: underline;
 }
 
-/* line 32, ../sass/partials/_proposals.scss */
+/* line 30, ../sass/partials/_proposals.scss */
 .drupalcamp-speaker,
 .session-type-label,
 .session-level-label {
@@ -819,7 +883,7 @@ h6 a,
   margin-bottom: 0.5em;
 }
 
-/* line 48, ../sass/partials/_proposals.scss */
+/* line 47, ../sass/partials/_proposals.scss */
 #block-views-block-your-proposals-block-your-proposals-list p,
 #block-views-block-your-proposals-block-your-proposals-list a {
   text-transform: none;
@@ -827,7 +891,7 @@ h6 a,
   margin: 0;
 }
 
-/* line 56, ../sass/partials/_proposals.scss */
+/* line 55, ../sass/partials/_proposals.scss */
 .field__label,
 .field__item {
   font-weight: normal;
@@ -849,7 +913,7 @@ h6 a,
 .profile .field__label::after {
   content: ":";
 }
-/* line 75, ../sass/partials/_proposals.scss */
+/* line 74, ../sass/partials/_proposals.scss */
 .profile .field__label,
 .profile .field__item {
   float: left;
@@ -869,7 +933,7 @@ h6 a,
 
 /* line 94, ../sass/partials/_proposals.scss */
 .item-list ul {
-  color: white;
+  color: #fff;
 }
 
 /* line 100, ../sass/partials/_proposals.scss */
@@ -881,7 +945,7 @@ h6 a,
 .flexslider .slides img {
   margin: 0 auto;
 }
-/* line 112, ../sass/partials/_proposals.scss */
+/* line 110, ../sass/partials/_proposals.scss */
 .flexslider .col-md-9.speaker-drupalcamp-topic,
 .flexslider .col-md-9.drupalcamp-speaker,
 .flexslider .col-md-9.topic-summary {
@@ -928,7 +992,7 @@ h6 a,
   padding-right: 2.5em;
 }
 
-/* line 149, ../sass/partials/_proposals.scss */
+/* line 146, ../sass/partials/_proposals.scss */
 .slides,
 .slides > li,
 .flex-control-nav,
@@ -949,11 +1013,11 @@ ol.flex-control-nav {
   font-weight: 700;
 }
 
-/* line 165, ../sass/partials/_proposals.scss */
+/* line 163, ../sass/partials/_proposals.scss */
 .type,
 .level,
 .room {
-  color: white;
+  color: #fff;
   padding: 0.4em;
   text-transform: uppercase;
   padding-left: 1.5em;
@@ -1004,7 +1068,7 @@ h3.speaker-drupalcamp-topic {
   margin: 0 auto;
   text-align: center;
   background-color: #fcb040;
-  color: white;
+  color: #fff;
   font-family: "Montserrat", sans-serif;
 }
 
@@ -1017,7 +1081,7 @@ h3.speaker-drupalcamp-topic {
     width: 40%;
   }
 
-  /* line 223, ../sass/partials/_proposals.scss */
+  /* line 221, ../sass/partials/_proposals.scss */
   .type,
   .level,
   .room {
@@ -1037,7 +1101,7 @@ h3.speaker-drupalcamp-topic {
   .flexslider .slides img {
     width: 100%;
   }
-  /* line 243, ../sass/partials/_proposals.scss */
+  /* line 241, ../sass/partials/_proposals.scss */
   .flexslider .col-md-9.speaker-drupalcamp-topic,
   .flexslider .col-md-9.drupalcamp-speaker,
   .flexslider .col-md-9.topic-summary {
@@ -1049,7 +1113,7 @@ h3.speaker-drupalcamp-topic {
     font-size: 1.2em;
   }
 
-  /* line 251, ../sass/partials/_proposals.scss */
+  /* line 250, ../sass/partials/_proposals.scss */
   .col-md-9.session-type-label,
   .col-md-9.session-level-label {
     float: right;

--- a/www/themes/custom/drupalcampcebu2015/public/css/style.css
+++ b/www/themes/custom/drupalcampcebu2015/public/css/style.css
@@ -18,10 +18,10 @@
   background-color: #1664a6;
   padding: 1.5em;
 }
-/* line 13, ../sass/partials/_header.scss */
+/* line 14, ../sass/partials/_header.scss */
 .header-info-top p,
 .header-info-top h2 {
-  color: #fff;
+  color: white;
   text-transform: uppercase;
   font-family: "Montserrat", sans-serif;
   font-size: 1.1em;
@@ -38,7 +38,7 @@
   text-align: center;
 }
 
-/* line 34, ../sass/partials/_header.scss */
+/* line 35, ../sass/partials/_header.scss */
 .content h1,
 .content h2,
 .region-header-info-bottom h1,
@@ -109,7 +109,7 @@
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-4 {
   padding: 0;
 }
-/* line 21, ../sass/partials/_newsletter.scss */
+/* line 22, ../sass/partials/_newsletter.scss */
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-3,
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-8 {
   padding-left: 0;
@@ -120,7 +120,7 @@
 .newsletter form #mc_embed_signup_scroll .mc-field-group .col-md-8 label {
   font-weight: normal;
 }
-/* line 33, ../sass/partials/_newsletter.scss */
+/* line 34, ../sass/partials/_newsletter.scss */
 .newsletter .email-address,
 .newsletter .firstname {
   color: #fcb040;
@@ -140,7 +140,7 @@
   padding: 0.3em;
   width: 100%;
   margin-top: 0.5em;
-  color: #fff;
+  color: white;
   background-color: #fcb040;
   border: none;
   text-transform: uppercase;
@@ -166,7 +166,7 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1.8em;
   font-weight: 700;
   margin: 0;
-  color: #fff;
+  color: white;
 }
 
 /* line 20, ../sass/partials/_global.scss */
@@ -235,7 +235,7 @@ img {
 }
 /* line 75, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(1) a, .region-sidebar ul.menu li:nth-child(1) p, .region-sidebar ul.menu li:nth-child(1) h3 {
-  color: #fff;
+  color: white;
 }
 
 /* line 82, ../sass/partials/_global.scss */
@@ -244,7 +244,7 @@ img {
 }
 /* line 84, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(2) a, .region-sidebar ul.menu li:nth-child(2) p, .region-sidebar ul.menu li:nth-child(2) h3 {
-  color: #fff;
+  color: white;
 }
 
 /* line 91, ../sass/partials/_global.scss */
@@ -253,7 +253,7 @@ img {
 }
 /* line 93, ../sass/partials/_global.scss */
 .region-sidebar ul.menu li:nth-child(3) a, .region-sidebar ul.menu li:nth-child(3) p, .region-sidebar ul.menu li:nth-child(3) h3 {
-  color: #fff;
+  color: white;
 }
 
 /* line 99, ../sass/partials/_global.scss */
@@ -270,11 +270,11 @@ a:hover {
 
 /* line 109, ../sass/partials/_global.scss */
 .header-info-top a {
-  color: #fff;
+  color: white;
 }
 /* line 112, ../sass/partials/_global.scss */
 .header-info-top a:hover {
-  color: #fff;
+  color: white;
 }
 
 /* line 117, ../sass/partials/_global.scss */
@@ -297,13 +297,13 @@ p.subtitle {
   float: left;
   padding-right: 2em;
 }
-/* line 137, ../sass/partials/_global.scss */
+/* line 138, ../sass/partials/_global.scss */
 .profile .field__label,
 .profile .field__item {
   color: #1664a6;
   font-size: 1.1em;
 }
-/* line 143, ../sass/partials/_global.scss */
+/* line 144, ../sass/partials/_global.scss */
 .profile .form-item,
 .profile .form-item h4.label {
   color: #1664a6;
@@ -348,7 +348,7 @@ p.subtitle {
 /* BREAKPOINT SECTION FOR USER PROFILE */
 /* ================== */
 @media only screen and (min-width: 420px) {
-  /* line 189, ../sass/partials/_global.scss */
+  /* line 190, ../sass/partials/_global.scss */
   .profile .field__label,
   .profile .field__item {
     font-size: 1.3em;
@@ -368,7 +368,7 @@ p.subtitle {
   }
 }
 @media only screen and (min-width: 1290px) {
-  /* line 210, ../sass/partials/_global.scss */
+  /* line 211, ../sass/partials/_global.scss */
   .profile .field__label,
   .profile .field__item {
     font-size: 1.5em;
@@ -400,7 +400,7 @@ p.subtitle {
 .promote-sponsor-tab p:nth-child(2) {
   font-size: 1.5em;
 }
-/* line 11, ../sass/partials/_sponsors.scss */
+/* line 12, ../sass/partials/_sponsors.scss */
 .promote-sponsor-tab p:nth-child(1),
 .promote-sponsor-tab p:nth-child(2) {
   color: #1664a6;
@@ -412,7 +412,7 @@ p.subtitle {
   color: #1664a6;
 }
 
-/* line 22, ../sass/partials/_sponsors.scss */
+/* line 23, ../sass/partials/_sponsors.scss */
 .view-sponsors,
 .view-sponsors-and-partners-page {
   overflow: hidden;
@@ -431,7 +431,7 @@ p.subtitle {
 .sponsor-header {
   /* Possible fix for the bug in sponsor tabs background-color */
 }
-/* line 35, ../sass/partials/_sponsors.scss */
+/* line 36, ../sass/partials/_sponsors.scss */
 .sponsor-header a,
 .sponsor-header h3 {
   color: #fff;
@@ -459,40 +459,46 @@ p.subtitle {
   z-index: -1;
 }
 
-/* line 61, ../sass/partials/_sponsors.scss */
+/* line 60, ../sass/partials/_sponsors.scss */
+.view-id-sponsors_and_partners_page .view-content .views-row img {
+  margin-top: 1em;
+  margin-bottom: 2em;
+}
+
+/* line 66, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-header.col-md-4, .view-id-sponsors_and_partners_page .view-header.col-md-4 {
   float: left;
   width: 100%;
 }
-/* line 65, ../sass/partials/_sponsors.scss */
+/* line 70, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-header.col-md-4 h3, .view-id-sponsors_and_partners_page .view-header.col-md-4 h3 {
   padding-top: 1em;
   text-align: center;
 }
-/* line 70, ../sass/partials/_sponsors.scss */
+/* line 75, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-content.col-md-4, .view-id-sponsors_and_partners_page .view-content.col-md-4 {
   float: right;
 }
-/* line 73, ../sass/partials/_sponsors.scss */
+/* line 78, ../sass/partials/_sponsors.scss */
 .view-id-sponsors a, .view-id-sponsors_and_partners_page a {
   color: #fff;
   text-decoration: underline;
   text-transform: uppercase;
 }
 
-/* line 80, ../sass/partials/_sponsors.scss */
+/* line 86, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content,
 .view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content {
   width: 100%;
 }
-/* line 83, ../sass/partials/_sponsors.scss */
+/* line 88, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul,
 .view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul {
   list-style: none;
   margin-top: 0.5em;
   text-align: center;
 }
-/* line 87, ../sass/partials/_sponsors.scss */
+/* line 92, ../sass/partials/_sponsors.scss */
 .view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul li,
 .view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul li {
   margin: 0;
@@ -500,20 +506,20 @@ p.subtitle {
   margin-right: 2em;
 }
 
-/* line 97, ../sass/partials/_sponsors.scss */
+/* line 103, ../sass/partials/_sponsors.scss */
 .view-display-id-block_sponsor_gold .view-header.col-md-4 .sponsor-header,
 .view-display-id-block_sponsor_gold .view-header.col-md-4 .view-id-sponsor_link .view-content {
   background-color: #fcb040;
 }
 
-/* line 106, ../sass/partials/_sponsors.scss */
+/* line 111, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-silver .sponsor-header,
 #block-views-block-sponsors-and-partners-page-block-sponsor-silver .sponsor-header,
 #block-views-block-sponsors-and-partners-page-block-partners .sponsor-header {
   background-color: #1664a6;
 }
 
-/* line 117, ../sass/partials/_sponsors.scss */
+/* line 122, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-bronze .sponsor-header,
 #block-views-block-sponsors-and-partners-page-block-sponsor-bronze .sponsor-header,
 #block-views-block-sponsors-and-partners-page-block-code-sprint .sponsor-header,
@@ -523,7 +529,7 @@ p.subtitle {
   background-color: #89caae;
 }
 
-/* line 122, ../sass/partials/_sponsors.scss */
+/* line 131, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-and-partners-page-block-code-sprint,
 #block-views-block-sponsors-and-partners-page-block-coffee,
 #block-views-block-sponsors-and-partners-page-block-saturday-lunch,
@@ -532,31 +538,31 @@ p.subtitle {
   margin-top: 1.2em;
 }
 
-/* line 130, ../sass/partials/_sponsors.scss */
+/* line 135, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-promote .sponsor-header {
   padding: 3em 1.6em 1em;
 }
 
-/* line 135, ../sass/partials/_sponsors.scss */
+/* line 140, ../sass/partials/_sponsors.scss */
 .view-id-sponsor_link .view-content {
   float: left;
 }
 
 /* View should be hidden without content, but view still showing in the markup.
 Temporary fix, display: none. */
-/* line 142, ../sass/partials/_sponsors.scss */
+/* line 148, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-and-partners-page-block-saturday-lunch,
 #block-views-block-sponsors-and-partners-page-block-sat-night {
   display: none;
 }
 
 /* 'See all sponsors' button displayed except on /sponsors page. */
-/* line 148, ../sass/partials/_sponsors.scss */
+/* line 153, ../sass/partials/_sponsors.scss */
 .path-sponsors .all-sponsor-button {
   display: none;
 }
 
-/* line 152, ../sass/partials/_sponsors.scss */
+/* line 157, ../sass/partials/_sponsors.scss */
 .region-sponsors .view-empty a {
   color: #fff;
   display: block;
@@ -567,13 +573,13 @@ Temporary fix, display: none. */
   margin: 15px 0;
 }
 
-/* line 163, ../sass/partials/_sponsors.scss */
+/* line 168, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-gold .view-empty a {
   background-color: #fcb040;
   font-size: 1.6em;
 }
 
-/* line 172, ../sass/partials/_sponsors.scss */
+/* line 177, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-silver
 #block-views-block-sponsors-and-partners-page-block-sponsor-silver .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-partners .view-empty a {
@@ -581,7 +587,7 @@ Temporary fix, display: none. */
   font-size: 1.4em;
 }
 
-/* line 184, ../sass/partials/_sponsors.scss */
+/* line 189, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-bronze .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-sponsor-bronze .view-empty a,
 #block-views-block-sponsors-and-partners-page-block-code-sprint .view-empty a,
@@ -592,10 +598,10 @@ Temporary fix, display: none. */
   font-size: 1.3em;
 }
 
-/* line 190, ../sass/partials/_sponsors.scss */
+/* line 195, ../sass/partials/_sponsors.scss */
 #block-views-block-sponsors-block-sponsor-promote .view-empty a {
   background-color: #fcb040;
-  color: #fff;
+  color: white;
   font-size: 1.5em;
   height: auto;
   padding: 20px;
@@ -607,12 +613,12 @@ Temporary fix, display: none. */
 /* ================== */
 /* Sponsor override float into table display to center items */
 @media (min-width: 992px) {
-  /* line 205, ../sass/partials/_sponsors.scss */
+  /* line 211, ../sass/partials/_sponsors.scss */
   .view-sponsors,
   .view-sponsors-and-partners-page {
     width: 100%;
   }
-  /* line 208, ../sass/partials/_sponsors.scss */
+  /* line 213, ../sass/partials/_sponsors.scss */
   .view-sponsors .views-row,
   .view-sponsors-and-partners-page .views-row {
     text-align: left;
@@ -620,44 +626,52 @@ Temporary fix, display: none. */
     padding-left: 1em;
   }
 
-  /* line 215, ../sass/partials/_sponsors.scss */
+  /* line 220, ../sass/partials/_sponsors.scss */
+  .view-id-sponsors_and_partners_page .view-content .views-row img {
+    margin: 0;
+  }
+
+  /* line 224, ../sass/partials/_sponsors.scss */
   .sponsor-header {
     padding-top: 3em;
     padding-left: 1.6em;
   }
 
-  /* line 221, ../sass/partials/_sponsors.scss */
+  /* line 230, ../sass/partials/_sponsors.scss */
   .view-id-sponsors .view-header.col-md-4, .view-id-sponsors_and_partners_page .view-header.col-md-4 {
     width: 33.33333333%;
   }
-  /* line 224, ../sass/partials/_sponsors.scss */
+  /* line 233, ../sass/partials/_sponsors.scss */
   .view-id-sponsors .view-header.col-md-4 h3, .view-id-sponsors_and_partners_page .view-header.col-md-4 h3 {
     text-align: left;
   }
-  /* line 227, ../sass/partials/_sponsors.scss */
+  /* line 236, ../sass/partials/_sponsors.scss */
   .view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content ul, .view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content ul {
     text-align: left;
   }
 
-  /* line 234, ../sass/partials/_sponsors.scss */
+  /* line 243, ../sass/partials/_sponsors.scss */
   .view-sponsor-link.view-id-sponsor_link {
     min-height: 11em;
     overflow: hidden;
   }
 
-  /* line 239, ../sass/partials/_sponsors.scss */
+  /* line 248, ../sass/partials/_sponsors.scss */
   .view-sponsor-link.view-display-id-block_link_silver {
     min-height: 9em;
     overflow: hidden;
   }
 
-  /* line 243, ../sass/partials/_sponsors.scss */
-  .view-sponsor-link.view-display-id-block_link_bronze {
+  /* line 255, ../sass/partials/_sponsors.scss */
+  .view-sponsor-link.view-display-id-block_link_bronze,
+  .view-sponsor-link.view-display-id-block_link_code_sprint,
+  .view-sponsor-link.view-display-id-block_link_coffee_snacks,
+  .view-sponsor-link.view-display-id-block_link_partners {
     min-height: 7em;
     overflow: hidden;
   }
 
-  /* line 249, ../sass/partials/_sponsors.scss */
+  /* line 264, ../sass/partials/_sponsors.scss */
   .view-sponsors .view-empty,
   .view-sponsors-and-partners-page .view-empty,
   .view-sponsors .view-content,
@@ -665,27 +679,27 @@ Temporary fix, display: none. */
     vertical-align: middle;
   }
 
-  /* line 256, ../sass/partials/_sponsors.scss */
+  /* line 268, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .view-empty a {
     display: inline-block;
   }
 
-  /* line 260, ../sass/partials/_sponsors.scss */
+  /* line 272, ../sass/partials/_sponsors.scss */
   #block-views-block-sponsors-block-sponsor-promote .sponsor-header {
     padding: 3em 1.6em;
   }
 }
-/* line 265, ../sass/partials/_sponsors.scss */
+/* line 277, ../sass/partials/_sponsors.scss */
 .col-md-8.camp-button-wrapper {
   float: right;
   margin-top: 1em;
 }
 
-/* line 271, ../sass/partials/_sponsors.scss */
+/* line 283, ../sass/partials/_sponsors.scss */
 .view-footer li p {
   margin-bottom: 0;
 }
-/* line 274, ../sass/partials/_sponsors.scss */
+/* line 286, ../sass/partials/_sponsors.scss */
 .view-footer li::before {
   display: none;
 }
@@ -705,12 +719,12 @@ Temporary fix, display: none. */
 .footer-container img.membership-logo {
   padding: 0 0 16px;
 }
-/* line 13, ../sass/partials/_footer.scss */
+/* line 14, ../sass/partials/_footer.scss */
 .footer-container div:nth-child(1),
 .footer-container div:nth-child(2) {
   text-align: center;
   font-size: 0.8em;
-  color: #fff;
+  color: white;
   font-family: "Open Sans", sans-serif;
   padding-bottom: 0.5em;
   font-weight: 300;
@@ -718,7 +732,7 @@ Temporary fix, display: none. */
 /* line 21, ../sass/partials/_footer.scss */
 .footer-container div:nth-child(1) p a,
 .footer-container div:nth-child(2) p a {
-  color: #fff;
+  color: white;
 }
 
 @media only screen and (min-width: 420px) {
@@ -726,7 +740,7 @@ Temporary fix, display: none. */
   #site-wrapper .site-logo {
     margin-bottom: 2.5em;
   }
-  /* line 7, ../sass/partials/_media-queries.scss */
+  /* line 8, ../sass/partials/_media-queries.scss */
   #site-wrapper .header-info-top,
   #site-wrapper .header-info-bottom {
     text-align: left;
@@ -734,7 +748,7 @@ Temporary fix, display: none. */
     padding-top: 3.5em;
     padding-bottom: 5.5em;
   }
-  /* line 10, ../sass/partials/_media-queries.scss */
+  /* line 11, ../sass/partials/_media-queries.scss */
   #site-wrapper .header-info-top h3,
   #site-wrapper .header-info-top p,
   #site-wrapper .header-info-bottom h3,
@@ -762,7 +776,7 @@ Temporary fix, display: none. */
     font-size: 2.1em;
     margin-top: 1.5em;
   }
-  /* line 38, ../sass/partials/_media-queries.scss */
+  /* line 39, ../sass/partials/_media-queries.scss */
   #site-wrapper .newsletter .email-address,
   #site-wrapper .newsletter .firstname {
     font-size: 1.5em;
@@ -812,7 +826,7 @@ Temporary fix, display: none. */
   }
 }
 @media only screen and (min-width: 1290px) {
-  /* line 86, ../sass/partials/_media-queries.scss */
+  /* line 87, ../sass/partials/_media-queries.scss */
   .header-info-top h3,
   .header-info-top p {
     font-size: 1.2em;
@@ -837,7 +851,7 @@ h1 {
   text-align: left;
 }
 
-/* line 8, ../sass/partials/_proposals.scss */
+/* line 9, ../sass/partials/_proposals.scss */
 h6,
 .speaker-announcement {
   color: #1664a6;
@@ -864,7 +878,7 @@ h6 a,
   text-decoration: underline;
 }
 
-/* line 30, ../sass/partials/_proposals.scss */
+/* line 32, ../sass/partials/_proposals.scss */
 .drupalcamp-speaker,
 .session-type-label,
 .session-level-label {
@@ -883,7 +897,7 @@ h6 a,
   margin-bottom: 0.5em;
 }
 
-/* line 47, ../sass/partials/_proposals.scss */
+/* line 48, ../sass/partials/_proposals.scss */
 #block-views-block-your-proposals-block-your-proposals-list p,
 #block-views-block-your-proposals-block-your-proposals-list a {
   text-transform: none;
@@ -891,7 +905,7 @@ h6 a,
   margin: 0;
 }
 
-/* line 55, ../sass/partials/_proposals.scss */
+/* line 56, ../sass/partials/_proposals.scss */
 .field__label,
 .field__item {
   font-weight: normal;
@@ -913,7 +927,7 @@ h6 a,
 .profile .field__label::after {
   content: ":";
 }
-/* line 74, ../sass/partials/_proposals.scss */
+/* line 75, ../sass/partials/_proposals.scss */
 .profile .field__label,
 .profile .field__item {
   float: left;
@@ -933,7 +947,7 @@ h6 a,
 
 /* line 94, ../sass/partials/_proposals.scss */
 .item-list ul {
-  color: #fff;
+  color: white;
 }
 
 /* line 100, ../sass/partials/_proposals.scss */
@@ -945,7 +959,7 @@ h6 a,
 .flexslider .slides img {
   margin: 0 auto;
 }
-/* line 110, ../sass/partials/_proposals.scss */
+/* line 112, ../sass/partials/_proposals.scss */
 .flexslider .col-md-9.speaker-drupalcamp-topic,
 .flexslider .col-md-9.drupalcamp-speaker,
 .flexslider .col-md-9.topic-summary {
@@ -992,7 +1006,7 @@ h6 a,
   padding-right: 2.5em;
 }
 
-/* line 146, ../sass/partials/_proposals.scss */
+/* line 149, ../sass/partials/_proposals.scss */
 .slides,
 .slides > li,
 .flex-control-nav,
@@ -1013,11 +1027,11 @@ ol.flex-control-nav {
   font-weight: 700;
 }
 
-/* line 163, ../sass/partials/_proposals.scss */
+/* line 165, ../sass/partials/_proposals.scss */
 .type,
 .level,
 .room {
-  color: #fff;
+  color: white;
   padding: 0.4em;
   text-transform: uppercase;
   padding-left: 1.5em;
@@ -1068,7 +1082,7 @@ h3.speaker-drupalcamp-topic {
   margin: 0 auto;
   text-align: center;
   background-color: #fcb040;
-  color: #fff;
+  color: white;
   font-family: "Montserrat", sans-serif;
 }
 
@@ -1081,7 +1095,7 @@ h3.speaker-drupalcamp-topic {
     width: 40%;
   }
 
-  /* line 221, ../sass/partials/_proposals.scss */
+  /* line 223, ../sass/partials/_proposals.scss */
   .type,
   .level,
   .room {
@@ -1101,7 +1115,7 @@ h3.speaker-drupalcamp-topic {
   .flexslider .slides img {
     width: 100%;
   }
-  /* line 241, ../sass/partials/_proposals.scss */
+  /* line 243, ../sass/partials/_proposals.scss */
   .flexslider .col-md-9.speaker-drupalcamp-topic,
   .flexslider .col-md-9.drupalcamp-speaker,
   .flexslider .col-md-9.topic-summary {
@@ -1113,7 +1127,7 @@ h3.speaker-drupalcamp-topic {
     font-size: 1.2em;
   }
 
-  /* line 250, ../sass/partials/_proposals.scss */
+  /* line 251, ../sass/partials/_proposals.scss */
   .col-md-9.session-type-label,
   .col-md-9.session-level-label {
     float: right;

--- a/www/themes/custom/drupalcampcebu2015/public/js/flexslider/drupalcampcebu2015.flexslider.js
+++ b/www/themes/custom/drupalcampcebu2015/public/js/flexslider/drupalcampcebu2015.flexslider.js
@@ -9,7 +9,7 @@
       // This is the recommended approach for Flexslider.
       $(window).load(function() {
         $('.flexslider').flexslider({
-          animation: "slide"
+          animation: "fade"
         });
       });
     }

--- a/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
+++ b/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
@@ -57,6 +57,11 @@
   }
 }
 
+.view-id-sponsors_and_partners_page .view-content .views-row img {
+  margin-top: 1em;
+  margin-bottom: 2em;
+}
+
 .view-id-sponsors, .view-id-sponsors_and_partners_page {
   .view-header.col-md-4 {
     float: left;
@@ -212,6 +217,10 @@ Temporary fix, display: none. */
     }
   }
 
+  .view-id-sponsors_and_partners_page .view-content .views-row img {
+    margin: 0;
+  }
+
   .sponsor-header {
     padding-top: 3em;
     padding-left: 1.6em;
@@ -240,7 +249,10 @@ Temporary fix, display: none. */
     min-height: 9em;
     overflow: hidden;
   }
-  .view-sponsor-link.view-display-id-block_link_bronze {
+  .view-sponsor-link.view-display-id-block_link_bronze,
+  .view-sponsor-link.view-display-id-block_link_code_sprint,
+  .view-sponsor-link.view-display-id-block_link_coffee_snacks,
+  .view-sponsor-link.view-display-id-block_link_partners {
     min-height: 7em;
     overflow: hidden;
   }

--- a/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
+++ b/www/themes/custom/drupalcampcebu2015/public/sass/partials/_sponsors.scss
@@ -23,17 +23,79 @@
 .view-sponsors-and-partners-page {
   @include clearfix();
   .views-row {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: 0.5em;
+    padding-bottom: 1.5em;
     text-align: center;
   }
 }
 
-/* Sponsor header background */
-#block-views-block-sponsors-block-sponsor-gold,
-#block-views-block-sponsors-and-partners-page-block-sponsor-gold {
-  overflow: hidden;
-  .sponsor-header {
+/* Sponsor header text */
+.sponsor-header {
+  /* Possible fix for the bug in sponsor tabs background-color */
+  a,
+  h3 {
+    color: #fff;
+  }
+  h3 {
+    font-size: 1.8em;
+    font-weight: 700;
+    margin: 0;
+  }
+  a {
+    font-size: 1.3em;
+    text-transform: uppercase;
+  }
+  &:before {
+    background-color: inherit;
+    height: 100%;
+    content: "";
+    left: 15px;
+    position: absolute;
+    right: 15px;
+    top: 0;
+    z-index: -1;
+  }
+}
+
+.view-id-sponsors, .view-id-sponsors_and_partners_page {
+  .view-header.col-md-4 {
+    float: left;
+    // We need the background to cover the whole col-4 area.
+    width: 100%;
+    h3 {
+      padding-top: 1em;
+      text-align: center;
+    }
+  }
+  .view-content.col-md-4 {
+    float: right;
+  }
+  a {
+    color: #fff;
+    text-decoration: underline;
+    text-transform: uppercase;
+  }
+}
+
+.view-id-sponsors .view-header.col-md-4 .view-id-sponsor_link .view-content,
+.view-id-sponsors_and_partners_page .view-header.col-md-4 .view-id-sponsor_link .view-content {
+  width: 100%;
+  ul {
+    list-style: none;
+    margin-top: 0.5em;
+    text-align: center;
+    li {
+      margin: 0;
+      margin-left: 2em;
+      margin-right: 2em;
+    }
+  }
+
+}
+
+.view-display-id-block_sponsor_gold .view-header.col-md-4 {
+  .sponsor-header,
+  .view-id-sponsor_link .view-content {
     background-color: $color-orange;
   }
 }
@@ -69,6 +131,12 @@
   padding: 3em 1.6em 1em;
 }
 
+.view-id-sponsor_link {
+  .view-content {
+    float: left;
+  }
+}
+
 /* View should be hidden without content, but view still showing in the markup.
 Temporary fix, display: none. */
 #block-views-block-sponsors-and-partners-page-block-saturday-lunch,
@@ -79,36 +147,6 @@ Temporary fix, display: none. */
 /* 'See all sponsors' button displayed except on /sponsors page. */
 .path-sponsors .all-sponsor-button {
   display: none;
-}
-
-/* Sponsor header text */
-.sponsor-header {
-  padding: 3em 1.6em;
-  /* Possible fix for the bug in sponsor tabs background-color */
-  // overflow: hidden;
-  a,
-  h3 {
-    color: #fff;
-  }
-  h3 {
-    font-size: 1.8em;
-    font-weight: 700;
-    margin: 0;
-  }
-  a {
-    font-size: 1.3em;
-    text-transform: uppercase;
-  }
-  &:before {
-    background-color: inherit;
-    height: 100%;
-    content: "";
-    left: 15px;
-    position: absolute;
-    right: 15px;
-    top: 0;
-    z-index: -1;
-  }
 }
 
 .region-sponsors .view-empty a {
@@ -166,23 +204,45 @@ Temporary fix, display: none. */
 @media (min-width: 992px) {
   .view-sponsors ,
   .view-sponsors-and-partners-page {
-    display: table;
     width: 100%;
     .views-row {
-      text-align: unset;
+      text-align: left;
       display: inline-block;
       padding-left: 1em;
     }
   }
 
-  .view-sponsors .view-header,
-  .view-sponsors-and-partners-page .view-header,
-  .view-sponsors .view-empty,
-  .view-sponsors-and-partners-page .view-empty,
-  .view-sponsors .view-content,
-  .view-sponsors-and-partners-page .view-content {
-    display: table-cell;
-    float: none;
+  .sponsor-header {
+    padding-top: 3em;
+    padding-left: 1.6em;
+  }
+
+  .view-id-sponsors, .view-id-sponsors_and_partners_page {
+    .view-header.col-md-4 {
+      // The mobile first approach fixed it to 100%, we revert it here.
+      width: 33.33333333%;
+      h3 {
+        text-align: left;
+      }
+      .view-id-sponsor_link .view-content ul {
+        text-align: left;
+      }
+    }
+  }
+
+  // Default sponsor link.
+  .view-sponsor-link.view-id-sponsor_link {
+    min-height: 11em;
+    overflow: hidden;
+  }
+  // Specific sponsor link.
+  .view-sponsor-link.view-display-id-block_link_silver {
+    min-height: 9em;
+    overflow: hidden;
+  }
+  .view-sponsor-link.view-display-id-block_link_bronze {
+    min-height: 7em;
+    overflow: hidden;
   }
 
   // This vertically aligns the blank boxes and sponsor images.


### PR DESCRIPTION
Add a view 'block_link_silver' inside the header of the block 'silver sponsor' in views 'sponsors' and 'sponsors and partners page.
Add a view 'block_link_bronze' inside the header of the block 'bronze sponsor' in views 'sponsors' and 'sponsors and partners page'.
Add a view 'block_link_code_sprint' inside the header of the block 'code sprint sponsor' in views 'sponsors and partners page'.
Add a view 'block_link_coffee_snacks' inside the header of the block 'coffee and snacks sponsor' in views 'sponsors and partners page'.
Update sposnors.scss file. Sponsor logos needs margin in small resolution.
Set margin 0 for the same sponsor logos in big resolution.